### PR TITLE
Support for the Arduino Due

### DIFF
--- a/src/ArduinoUnit.h
+++ b/src/ArduinoUnit.h
@@ -27,6 +27,14 @@
 #endif
 #endif
 
+// Workaround for Arduino Due
+#if defined(__arm__) && !defined(PROGMEM)
+#define PROGMEM
+#define PSTR(s) s
+#define memcpy_P(a, b, c) memcpy(a, b, c)
+#define strlen_P(a) strlen(a)
+#endif
+
 #include <utility/FakeStream.h>
 #include <utility/FreeMemory.h>
 


### PR DESCRIPTION
PROGMEM is not available on Due, so compilation for Due fails. This workaround defines the PROGMEM macros so that PSTR(s) returns just s, for example.
