### PR TITLE
`flush()` function implementation

### DIFF
--- a/src/utility/FakeStream.cpp
+++ b/src/utility/FakeStream.cpp
@@ -34,8 +34,13 @@ size_t FakeStream::write(uint8_t val) {
 }
 
 void FakeStream::flush() {
-	_bytesWritten="";
-	setToEndOfStream();
+    // does nothing to avoid conflicts (false negative tests)
+    // for test purpose, use 'reset' function instead
+}
+
+void FakeStream::reset() {
+    _bytesWritten="";
+    setToEndOfStream();
 }
 
 const String& FakeStream::bytesWritten() {

--- a/src/utility/FakeStream.h
+++ b/src/utility/FakeStream.h
@@ -52,9 +52,15 @@ public:
     size_t write(uint8_t val);
 
     /**
-     * Flushes this stream. When called, 'bytesWritten' becomes empty  ("").
+     * Flushes this stream. Does nothing in this implementation to avoid conflicts (false negative tests).
      */
     void flush();
+
+    /**
+     * Reset the FakeStream so that it can be reused across tests. 
+     * When called, 'bytesWritten' becomes empty  ("").
+     */
+    void reset();
 
     /**
      * The bytes written by calling write(uint8_t).


### PR DESCRIPTION
Implements `flush()` function to cleanup the `FakeStream`.

Example : 

``` c
test(myTest)
{
  FakeStream stream;
  stream.write(0x00);
  assertEqual(stream.bytesWritten().length(),1);
  stream.flush();
  assertEqual(stream.bytesWritten(), "");
  assertEqual(stream.bytesWritten().length(), 0);
}
```
