### PR TITLE
Added serial support for the Arduino Leonardo/Micro.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -71,6 +71,7 @@ test(bad)
 void setup()
 {
   Serial.begin(9600);
+  while(!Serial); // for the Arduino Leonardo/Micro only
 }
 
 void loop()
@@ -330,6 +331,7 @@ A single test `my_test`
 void setup()
 {
   Serial.begin(9600);
+  while(!Serial); // for the Arduino Leonardo/Micro only
   Test::exclude("*");
   Test::include("my_test");
 }
@@ -340,6 +342,7 @@ All tests named dev_-something, but not the ones ending in _skip or _slow, or ha
 void setup()
 {
   Serial.begin(9600);
+  while(!Serial); // for the Arduino Leonardo/Micro only
   Test::exclude("*");
   Test::include("dev_*");
   Test::exclude("*_slow");
@@ -380,6 +383,9 @@ A. Here is a troubleshooting guideline:
  * Make sure you call `Serial.begin()` in your setup.  Or, if you redirect
    output by changing the value of `Test::out`, make sure you configure
    the Print stream you direct it to.
+ * If you are using an Arduino Leonardo/Micro: don't forget to add 
+   `while(!Serial)` after `Serial.begin(9600)` in the setup(). Without this line
+   nothing will be printed in the serial monitor.
  * Make sure you call `Test::run()` in your loop().
  * Make sure you did not exclude the test(s) with `Test::exclude(pattern)`.
    By default all tests are included.

--- a/src/examples/advanced/advanced.ino
+++ b/src/examples/advanced/advanced.ino
@@ -75,6 +75,7 @@ MyTest myTest3("myTest3");
 void setup()
 {
   Serial.begin(9600);
+  while(!Serial); // for the Arduino Leonardo/Micro only
 
   Test::min_verbosity |= TEST_VERBOSITY_ASSERTIONS_ALL;
   Test::exclude("my*2");

--- a/src/examples/basic/basic.ino
+++ b/src/examples/basic/basic.ino
@@ -16,6 +16,7 @@ test(incorrect)
 void setup()
 {
   Serial.begin(9600);
+  while(!Serial); // for the Arduino Leonardo/Micro only
 }
 
 void loop()

--- a/src/examples/continuous/continuous.ino
+++ b/src/examples/continuous/continuous.ino
@@ -19,6 +19,7 @@ testing(continuous)
 void setup()
 {
   Serial.begin(9600);
+  while(!Serial); // for the Arduino Leonardo/Micro only
 }
 
 void loop()

--- a/src/examples/digital_pin_test/digital_pin_test.ino
+++ b/src/examples/digital_pin_test/digital_pin_test.ino
@@ -42,6 +42,7 @@ THE SOFTWARE.
 
 void setup() {
     Serial.begin(9600);
+    while(!Serial); // for the Arduino Leonardo/Micro only
 }
 
 /**

--- a/src/examples/filter/filter.ino
+++ b/src/examples/filter/filter.ino
@@ -12,7 +12,8 @@ test(crypto_sha256) { pass(); }
 void setup()
 {
   Serial.begin(9600);
-
+  while(!Serial); // for the Arduino Leonardo/Micro only
+  
   // all tests named net_ - something, except net_ftp
   Test::exclude("*");
   Test::include("net_*");

--- a/src/examples/verbosity/verbosity.ino
+++ b/src/examples/verbosity/verbosity.ino
@@ -44,6 +44,7 @@ test(quiet_skip)
 void setup()
 {
   Serial.begin(9600);
+  while(!Serial); // for the Arduino Leonardo/Micro only
 }
 
 void loop()


### PR DESCRIPTION
Added the while(!Serial) line to the examples to support the Arduino Leonardo/Micro. If one of these boards is used and the while(!Serial) line is omitted, nothing will be printed in the serial monitor.
Also updates the readme accordingly.
