### PR TITLE
Making library compatible with Arduino 1.5.8+

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,8 @@
+name=ArduinoUnit
+version=2.1
+author=Matthew Murdoch
+maintainer=Matthew Murdoch <matthew.murdoch.0@gmail.com>
+sentence=Unit test framework for arduino projects.
+paragraph=ArduinoUnit is a unit testing framework for Arduino libraries.
+url=https://github.com/mmurdoch/arduinounit
+architectures=sam


### PR DESCRIPTION
Looks like in 1.5.x a new way of detecting the libraries is used. So the missing file was created and added.
