### PR TITLE
use a splat to work for any architecture, not just sam

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -5,4 +5,4 @@ maintainer=Matthew Murdoch <matthew.murdoch.0@gmail.com>
 sentence=Unit test framework for arduino projects.
 paragraph=ArduinoUnit is a unit testing framework for Arduino libraries.
 url=https://github.com/mmurdoch/arduinounit
-architectures=sam
+architectures=*


### PR DESCRIPTION
Use a splat rather than "sam" to specify this library is compatible with both avr and sam architectures.