### PR TITLE
Add category to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=Matthew Murdoch
 maintainer=Matthew Murdoch <matthew.murdoch.0@gmail.com>
 sentence=Unit test framework for arduino projects.
 paragraph=ArduinoUnit is a unit testing framework for Arduino libraries.
+category=Other
 url=https://github.com/mmurdoch/arduinounit
 architectures=*


### PR DESCRIPTION
Fixes the `WARNING: Category '' in library ArduinoUnit is not valid. Setting to 'Uncategorized'` warning in Arduino IDE 1.6.6. If you disagree with my category choice I'm happy to change the category to any of the other [valid category values](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification) and squash to a single commit.