### PR TITLE
Add support for the ESP8266 env. Fix headers in readme.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@ ArduinoUnit
 
 Unit test framework for arduino projects.
 
-##Current Version 2.2.0
+## Current Version 2.2.0
 [Download ArduinoUnit 2.2.0](https://github.com/mmurdoch/arduinounit/releases/tag/v2.2.0).
 
 ArduinoUnit 2.0 is a complete rewrite of ArduinoUnit based on the experience 
@@ -18,7 +18,7 @@ If you don't want to take advantage of the great new features in 2.0 then the
 latest release of the 1.x code line is still 
 [available for download](https://github.com/mmurdoch/arduinounit/tree/v1.7).
 
-##Why Version 2?
+## Why Version 2?
 
 ArduinoUnit 2 follows the spirit of ArduinoUnit 1.x with the following
 less-is-more features:
@@ -40,7 +40,7 @@ And the following more-is-more features:
    - Test names can optionally be stored in either RAM or flash.
 1. assertions about other tests.
 
-##Getting Started
+## Getting Started
 
 Create a directory called ArduinoUnit in your [Arduino Libraries Directory](http://arduino.cc/en/Guide/Libraries) e.g. `<arduino installation directory>\libraries`.
 
@@ -91,7 +91,7 @@ Test bad failed.
 Test ok passed.
 Test summary: 1 passed, 1 failed, and 0 skipped, out of 2 test(s).
 ```
-#Verbosity
+# Verbosity
 
 Just how much information is generated on each test is fairly flexible, and designed to address these rules:
 
@@ -138,7 +138,7 @@ TEST_VERBOSITY_ALL                (0x3F)
 TEST_VERBOSITY_NONE               (0x00)
 ```
 
-#Output
+# Output
 
 The `Test::out` value is the *shared* value for all tests describing where output for all tests goes.  The default is 
 
@@ -154,7 +154,7 @@ Test::out = &Serial3;
 
 in your `setup()`.  Note the library does not set the baud rate - you have to do that in your `setup()`.
 
-##Built-in Assertions
+## Built-in Assertions
 
 The following assertions are supported
 
@@ -215,7 +215,7 @@ assertions.
 
 All the assert macros expand to a test that creates an optional message, and, if false, calls fail() on the current test and returns.
 
-##Meta Assertions
+## Meta Assertions
 
 You can make assertions on the outcome of tests as well.  The following meta-assertions are supported:
 ```
@@ -267,7 +267,7 @@ testing(too_slow)
 Since the ordering tests cannot be controlled, only use test-asserts
 in a testing() environment.
 
-#`Test` and `TestOnce`
+# `Test` and `TestOnce`
 You can create your own modular tests by deriving from these classes.
 
 ```
@@ -319,7 +319,7 @@ MyTestOnce myTestOnce2("myTestOnce2");
 
 Note that `Test::run()` only calls the active unresolved tests.
 
-##Selecting tests
+## Selecting tests
 
 In your setup() function, you can select which tests are going to be setup and looped.  The default is that all tests are included.
 
@@ -329,7 +329,7 @@ In your setup() function, you can select which tests are going to be setup and l
 
 Here are some examples:
 
-##Select examples:
+## Select examples:
 
 A single test `my_test`
 
@@ -357,7 +357,7 @@ void setup()
 }
 ```
 
-##FAQ
+## FAQ
 
 Q. The line number of the asserts do not match the source file.
 
@@ -405,7 +405,7 @@ A. Here is a troubleshooting guideline:
    * Setting Test::min_verbosity = TEST_VERBOSITY_ALL (the default is TEST_VERSOBITY_TESTS_ALL | TEST_VERBOSITY_ASSERTIONS_FAILED, generating output only for failed assertions, completions of tests, and an overall summary).
    * With these settings, the per-test verbosity has no effect.
 
-##License
+## License
 
 Copyright (c) 2013 Warren MacEvoy, Matthew Murdoch, freenerd, John Macdonald,
 nicolaspanel, Matt Paine

--- a/src/ArduinoUnitUtility/ArduinoUnit.cpp
+++ b/src/ArduinoUnitUtility/ArduinoUnit.cpp
@@ -30,7 +30,7 @@ int8_t Test::TestString::compare(const Test::TestString &to) const
 {
   uint8_t a_buf[4],b_buf[4];
   uint16_t i=0;
-  
+
   for (;;) {
     uint8_t j=(i%4);
     if (j == 0) {
@@ -89,7 +89,7 @@ bool Test::TestString::matches(const char *pattern) const {
           k=j+1;
           state1[k/8] |= (1 << (k%8));
           while (pattern[k] == '*') {
-            ++k; 
+            ++k;
             state1[k/8] |= (1 << (k%8));
           }
         }
@@ -117,20 +117,20 @@ uint8_t Test::min_verbosity = TEST_VERBOSITY_TESTS_SUMMARY;
 
 Print* Test::out = &Serial;
 
-void Test::resolve() 
+void Test::resolve()
 {
   bool pass = current->state==DONE_PASS;
   bool fail = current->state==DONE_FAIL;
   bool skip = current->state==DONE_SKIP;
   bool done = (pass || fail || skip);
-  
+
   if (done) {
     if (pass) ++Test::passed;
     if (fail) ++Test::failed;
     if (skip) ++Test::skipped;
-    
+
 #if TEST_VERBOSITY_EXISTS(TESTS_SKIPPED) || TEST_VERBOSITY_EXISTS(TESTS_PASSED) || TEST_VERBOSITY_EXISTS(TESTS_FAILED)
-    
+
     bool output = false;
 
     output = output || (skip && TEST_VERBOSITY(TESTS_SKIPPED));
@@ -143,11 +143,11 @@ void Test::resolve()
 #if TEST_VERBOSITY_EXISTS(TESTS_SKIPPED)
       if (skip) out->println(F(" skipped."));
 #endif
-      
+
 #if TEST_VERBOSITY_EXISTS(TESTS_PASSED)
       if (pass) out->println(F(" passed."));
 #endif
-      
+
 #if TEST_VERBOSITY_EXISTS(TESTS_FAILED)
       if (fail) out->println(F(" failed."));
 #endif
@@ -166,6 +166,9 @@ void Test::resolve()
     out->print(count);
     out->println(F(" test(s)."));
   }
+#endif
+#ifdef ESP8266
+  yield();
 #endif
 }
 
@@ -232,6 +235,9 @@ void Test::run()
     } else {
       p=&((*p)->next);
     }
+#ifdef ESP8266
+    yield();
+#endif
   }
 }
 
@@ -261,7 +267,7 @@ void Test::exclude(const char *pattern)
 TestOnce::TestOnce(const __FlashStringHelper *name) : Test(name) {}
 TestOnce::TestOnce(const char *name) : Test(name) {}
 
-void TestOnce::loop() 
+void TestOnce::loop()
 {
   once();
   if (state == LOOPING) state = DONE_PASS;

--- a/src/ArduinoUnitUtility/Compare.h
+++ b/src/ArduinoUnitUtility/Compare.h
@@ -1,6 +1,20 @@
 #pragma once
 #if defined(F)
+#ifndef ESP8266
 #include <avr/pgmspace.h>
+#endif
+#ifdef ESP8266
+#undef PROGMEM
+#define PROGMEM
+#undef PSTR
+#define PSTR(s) (s)
+#undef pgm_read_byte
+#define pgm_read_byte(addr) (*reinterpret_cast<const uint8_t*>(addr))
+#undef pgm_read_word
+#define pgm_read_word(addr) (*reinterpret_cast<const uint16_t*>(addr))
+#endif
+
+#define typeof(x) __typeof__(x)
 #endif
 #include <WString.h>
 
@@ -8,32 +22,53 @@ template  < typename A, typename B > struct Compare
 {
   inline static int between(const A &a,const B &b)
   {
+#ifdef ESP8266
+    yield();
+#endif
     if (a<b) return -1;
     if (b<a) return  1;
     return 0;
   } // between
   inline static bool equal(const A &a,const B &b)
   {
+#ifdef ESP8266
+    yield();
+#endif
     return (!(a<b)) && (!(b<a));
   } // equal
   inline static bool notEqual(const A &a,const B &b)
   {
+#ifdef ESP8266
+    yield();
+#endif
     return (a<b) || (b<a);
   } // notEqual
   inline static bool less(const A &a,const B &b)
   {
+#ifdef ESP8266
+    yield();
+#endif
     return a<b;
   } // less
   inline static bool more(const A &a,const B &b)
   {
+#ifdef ESP8266
+    yield();
+#endif
     return b<a;
   } // more
   inline static bool lessOrEqual(const A &a,const B &b)
   {
+#ifdef ESP8266
+    yield();
+#endif
     return !(b<a);
   } // lessOrEqual
   inline static bool moreOrEqual(const A &a,const B &b)
   {
+#ifdef ESP8266
+    yield();
+#endif
     return !(a<b);
   } // moreOrEqual
 };

--- a/src/ArduinoUnitUtility/Compare.h
+++ b/src/ArduinoUnitUtility/Compare.h
@@ -12,9 +12,8 @@
 #define pgm_read_byte(addr) (*reinterpret_cast<const uint8_t*>(addr))
 #undef pgm_read_word
 #define pgm_read_word(addr) (*reinterpret_cast<const uint16_t*>(addr))
-#endif
-
 #define typeof(x) __typeof__(x)
+#endif
 #endif
 #include <WString.h>
 


### PR DESCRIPTION
Initial support for the ESP8266 env.:
- PROGMEM doesn't really make sense in ESP land.
- Sprinkle yield()s in likely spots to reduce the Watch Dog timer firing.
  This happened regularly on the advanced.ino example.
  That is, the ESP module will fire the software Watch Dog timer if it isn't fed approximately ever second or so. delay(), wdt_reset(), or yield()'s will feed it.
- Remove some trailing white space (thanks to my IDE)

Fixes #55 

readme.md:
- A white space is needed after '#' headings for them to work. Fixed malformed headings.

[Tested using basic.ino & advanced.ino. They seem to run as expected.]