### PR TITLE
Reduced program-storage footprint of assertion tests

### DIFF
--- a/examples/basic_with_include/basic_with_include.ino
+++ b/examples/basic_with_include/basic_with_include.ino
@@ -1,6 +1,6 @@
 #line 2 "basic.ino"
-//#define TEST_REDUCE_CODE_FOOTPRINT 1
 #include <ArduinoUnit.h>
+#include "do_assert.h"
 
 test(correct)
 {
@@ -12,7 +12,11 @@ test(incorrect)
 {
   int x=1;
   assertNotEqual(x,1);
-  assertNotEqual(x,1);
+}
+
+test(incorrect_included)
+{
+  performAssertion();  // included 
 }
 
 void setup()

--- a/examples/basic_with_include/do_assert.h
+++ b/examples/basic_with_include/do_assert.h
@@ -1,0 +1,13 @@
+#line 2 "do_assert.h"
+#include <ArduinoUnit.h>
+
+//
+// IMPORTANT: Create a test context to perform asserts in the context of tests declared elsewhere.
+//
+testcontext();
+
+void performAssertion() {
+  int y=1;
+  assertNotEqual(y,1);
+}
+

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@ ArduinoUnit
 
 Unit test framework for arduino projects.
 
-##Current Version 2.2.0
+## Current Version 2.2.0
 [Download ArduinoUnit 2.2.0](https://github.com/mmurdoch/arduinounit/releases/tag/v2.2.0).
 
 ArduinoUnit 2.0 is a complete rewrite of ArduinoUnit based on the experience 
@@ -18,7 +18,7 @@ If you don't want to take advantage of the great new features in 2.0 then the
 latest release of the 1.x code line is still 
 [available for download](https://github.com/mmurdoch/arduinounit/tree/v1.7).
 
-##Why Version 2?
+## Why Version 2?
 
 ArduinoUnit 2 follows the spirit of ArduinoUnit 1.x with the following
 less-is-more features:
@@ -40,7 +40,7 @@ And the following more-is-more features:
    - Test names can optionally be stored in either RAM or flash.
 1. assertions about other tests.
 
-##Getting Started
+## Getting Started
 
 Create a directory called ArduinoUnit in your [Arduino Libraries Directory](http://arduino.cc/en/Guide/Libraries) e.g. `<arduino installation directory>\libraries`.
 
@@ -91,7 +91,7 @@ Test bad failed.
 Test ok passed.
 Test summary: 1 passed, 1 failed, and 0 skipped, out of 2 test(s).
 ```
-#Verbosity
+# Verbosity
 
 Just how much information is generated on each test is fairly flexible, and designed to address these rules:
 
@@ -138,7 +138,7 @@ TEST_VERBOSITY_ALL                (0x3F)
 TEST_VERBOSITY_NONE               (0x00)
 ```
 
-#Output
+# Output
 
 The `Test::out` value is the *shared* value for all tests describing where output for all tests goes.  The default is 
 
@@ -154,7 +154,7 @@ Test::out = &Serial3;
 
 in your `setup()`.  Note the library does not set the baud rate - you have to do that in your `setup()`.
 
-##Built-in Assertions
+## Built-in Assertions
 
 The following assertions are supported
 
@@ -215,7 +215,7 @@ assertions.
 
 All the assert macros expand to a test that creates an optional message, and, if false, calls fail() on the current test and returns.
 
-##Meta Assertions
+## Meta Assertions
 
 You can make assertions on the outcome of tests as well.  The following meta-assertions are supported:
 ```
@@ -267,7 +267,7 @@ testing(too_slow)
 Since the ordering tests cannot be controlled, only use test-asserts
 in a testing() environment.
 
-#`Test` and `TestOnce`
+# `Test` and `TestOnce`
 You can create your own modular tests by deriving from these classes.
 
 ```
@@ -319,7 +319,7 @@ MyTestOnce myTestOnce2("myTestOnce2");
 
 Note that `Test::run()` only calls the active unresolved tests.
 
-##Selecting tests
+## Selecting tests
 
 In your setup() function, you can select which tests are going to be setup and looped.  The default is that all tests are included.
 
@@ -329,7 +329,7 @@ In your setup() function, you can select which tests are going to be setup and l
 
 Here are some examples:
 
-##Select examples:
+## Select examples:
 
 A single test `my_test`
 
@@ -357,7 +357,7 @@ void setup()
 }
 ```
 
-##FAQ
+## FAQ
 
 Q. The line number of the asserts do not match the source file.
 
@@ -365,7 +365,7 @@ A.  As far as I can tell, this is a bug in the compiler -- look two
    lines up.  I do not know why the `__LINE__` macro does not match
    the actual line of code.
 
-Q. What's with the `# 2 "file.ino"` business in the examples?
+Q. What's with the `#line 2 "file.ino"` business in the examples?
 
 A. This is to address question 1 above, and, without this line, the filename
    will be a very long and mostly useless name in the asserts, like,
@@ -376,6 +376,25 @@ A. This is to address question 1 above, and, without this line, the filename
 
   This uses up flash memory space and doesn't give any useful information when
   something goes wrong.
+
+Q. The assertions are eating up all my program storage space. What's happening?
+
+A. Here are two things you can do to reduce the storage footprint of assertion() statements:
+
+ * Make sure you add `#line 2 "filename.ino"` as the first line of your test program (see above).
+ * Enable the `TEST_REDUCE_CODE_FOOTPRINT 1` option before you include ArduinoUnit.
+   This is especially effective if you have long value expressions as arguments of your _assert_ statements like `assertNotEqual(myfunctionwithlongname(x),1)`. A side effect of this option is that it causes the literal value expressions to vanish from the error message displayed for failed asserts, e.g. 
+<pre>Assertion failed: (1 != 1), file 'file.ino', line 17.</pre>
+instead of
+<pre>Assertion failed: (myfunctionwithlongname(x)=1) != (1=1), file 'file.ino', line 17.</pre>
+However, the actual value and the expected value used by the assertion are still displayed and the error can easily be tracked back to the failing assertion via file name and line number. This is how it's done:
+
+<pre>
+#line 2 "file.ino"
+#define TEST_REDUCE_CODE_FOOTPRINT 1
+#include &lt;ArduinoUnit.h&gt;
+</pre>
+
 
 Q. I get these link errors about multiply defined test_XXXX_instance.
 
@@ -404,8 +423,8 @@ A. Here is a troubleshooting guideline:
    * Assuring that Test::max_verbosity is TEST_VERBOSITY_ALL (the default).
    * Setting Test::min_verbosity = TEST_VERBOSITY_ALL (the default is TEST_VERSOBITY_TESTS_ALL | TEST_VERBOSITY_ASSERTIONS_FAILED, generating output only for failed assertions, completions of tests, and an overall summary).
    * With these settings, the per-test verbosity has no effect.
-
-##License
+ 
+## License
 
 Copyright (c) 2013 Warren MacEvoy, Matthew Murdoch, freenerd, John Macdonald,
 nicolaspanel, Matt Paine

--- a/src/ArduinoUnitUtility/ArduinoUnit.cpp
+++ b/src/ArduinoUnitUtility/ArduinoUnit.cpp
@@ -179,14 +179,14 @@ void Test::remove()
   }
 }
 
-Test::Test(const __FlashStringHelper *_name, uint8_t _verbosity)
-  : name(_name), verbosity(_verbosity)
+Test::Test(const __FlashStringHelper *_name, const __FlashStringHelper *_filename, uint8_t _verbosity)
+  : name(_name), filename(_filename), verbosity(_verbosity)
 {
   insert();
 }
 
-Test::Test(const char *_name, uint8_t _verbosity)
-  : name(_name), verbosity(_verbosity)
+Test::Test(const char *_name, const __FlashStringHelper *_filename, uint8_t _verbosity)
+  : name(_name), filename(_filename), verbosity(_verbosity)
 {
   insert();
 }
@@ -235,6 +235,18 @@ void Test::run()
   }
 }
 
+const __FlashStringHelper *Test::opName(AssertOps op) {
+	switch(op) {
+		case AssertOps::EQUAL: return F(" == ");
+		case AssertOps::NOT_EQUAL: return F(" != ");
+		case AssertOps::LESS: return F(" < ");
+		case AssertOps::MORE: return F(" > ");
+		case AssertOps::LESS_OR_EQUAL: return F(" <= ");
+		case AssertOps::MORE_OR_EQUAL: return F(" >= ");
+		default: return F("Unknown AssertOp");
+	}
+}
+
 Test::~Test()
 {
   remove();
@@ -258,8 +270,8 @@ void Test::exclude(const char *pattern)
   }
 }
 
-TestOnce::TestOnce(const __FlashStringHelper *name) : Test(name) {}
-TestOnce::TestOnce(const char *name) : Test(name) {}
+TestOnce::TestOnce(const __FlashStringHelper *name, const __FlashStringHelper *filename) : Test(name, filename) {}
+TestOnce::TestOnce(const char *name, const __FlashStringHelper *filename) : Test(name, filename) {}
 
 void TestOnce::loop() 
 {

--- a/src/ArduinoUnitUtility/ArduinoUnit.cpp
+++ b/src/ArduinoUnitUtility/ArduinoUnit.cpp
@@ -179,14 +179,14 @@ void Test::remove()
   }
 }
 
-Test::Test(const __FlashStringHelper *_name, const __FlashStringHelper *_filename, uint8_t _verbosity)
-  : name(_name), filename(_filename), verbosity(_verbosity)
+Test::Test(const __FlashStringHelper *_name, uint8_t _verbosity)
+: name(_name), verbosity(_verbosity)
 {
   insert();
 }
 
-Test::Test(const char *_name, const __FlashStringHelper *_filename, uint8_t _verbosity)
-  : name(_name), filename(_filename), verbosity(_verbosity)
+Test::Test(const char *_name, uint8_t _verbosity)
+: name(_name), verbosity(_verbosity)
 {
   insert();
 }
@@ -270,8 +270,8 @@ void Test::exclude(const char *pattern)
   }
 }
 
-TestOnce::TestOnce(const __FlashStringHelper *name, const __FlashStringHelper *filename) : Test(name, filename) {}
-TestOnce::TestOnce(const char *name, const __FlashStringHelper *filename) : Test(name, filename) {}
+TestOnce::TestOnce(const __FlashStringHelper *name) : Test(name) {}
+TestOnce::TestOnce(const char *name) : Test(name) {}
 
 void TestOnce::loop() 
 {


### PR DESCRIPTION
Thanks for giving us ArduinoUnit — an invaluable tool for serious Arduino software development!

However, in my Arduino Uno projects I repeatedly ran into program-memory limitations when using ArduinoUnit because my tests required several libraries to be included and because I was using lots of assertions. 

This patch reduces assertion impact on program storage space by
1. capturing the file name only once per test rather than once per assertion
2. removing progmem constants for assertion operators (e.g. "==")
3. (optionally) omitting argument code in messages for failed assertions.

Analysis showed it's mainly each assertion's redefinition of the containing file name and the inclusion of the literal argument code in the message for failed assertions. The analysis was carried out on the basis of ArduinoUnit's “basic.ino” project. See the analysis result in the commit message. The byte numbers constitute a minimum baseline since the underlying assertion-argument code was just "(x,1)"; for more verbose arguments the storage saving is more substantial.

The patch also corrects heading formatting problems in readme.md.