### PR TITLE
Add an "on_failure" hook function

### DIFF
--- a/src/ArduinoUnit.h
+++ b/src/ArduinoUnit.h
@@ -582,8 +582,43 @@ namespace arduino_unit {
 #define decltype typeof
 #endif
 
+// When an assertion fails, the failure_return function is called and
+// its return value is returned. This can be used to let a failed
+// assertion return a value in non-void helper functions, but can also
+// be used to do cleanup or print some context on failure.
+//
+// This function is weak, so it can be replaced by another global
+// function. Alternatively, a local macro or callable variable can be
+// declared to shadow the global function. A lambda is typically
+// convenient for this. For example:
+//
+//      test(foo) {
+//        uint8_t i;
+//        auto on_failure = [&i]() { Serial.print("i = "); Serial.println(i); };
+//        for (i = 0; i < 10; ++i)
+//          assertTrue(doSomething(i));
+//      }
+//
+// Now, when doSomething returns false, the current value of i is
+// printed and then the foo test returns.
+//
+// The same approach can be used to modify the return value of a helper
+// function:
+//
+//   bool checkFoo(uint8_t v) {
+//     auto on_failure = []() { return false; }
+//     assertEqual(v, FOO);
+//     return true;
+//   }
+//
+// This particular example would be better using a macro, but this
+// scheme can be useful for a longer helper function containing multiple
+// asserts.
+void on_failure() __attribute__((__weak__));
+inline void on_failure() { }
+
 // helper define for the operators below
-#define assertOp(arg1,op,op_name,arg2) do { if (!Test::assertion<arduino_unit::remove_reference<decltype(arg1)>::type,arduino_unit::remove_reference<decltype(arg2)>::type>(F(__FILE__),__LINE__,F(#arg1),(arg1),F(op_name),op,F(#arg2),(arg2))) return; } while (0) 
+#define assertOp(arg1,op,op_name,arg2) do { if (!Test::assertion<arduino_unit::remove_reference<decltype(arg1)>::type,arduino_unit::remove_reference<decltype(arg2)>::type>(F(__FILE__),__LINE__,F(#arg1),(arg1),F(op_name),op,F(#arg2),(arg2))) { return on_failure(); } } while (0) 
 /** macro generates optional output and calls fail() followed by a return if false. */
 #define assertEqual(arg1,arg2)       assertOp(arg1,compareEqual,"==",arg2)
 

--- a/src/ArduinoUnit.h
+++ b/src/ArduinoUnit.h
@@ -572,9 +572,18 @@ elsewhere.  This is only necessary if you use assertTestXXXX when the test
 is in another file (or defined after the assertion on it). */
 #define externTesting(name) struct test_ ## name : Test { test_ ## name(); void loop(); }; extern test_##name test_##name##_instance
 
-// helper define for the operators below
-#define assertOp(arg1,op,op_name,arg2) do { if (!Test::assertion<typeof(arg1),typeof(arg2)>(F(__FILE__),__LINE__,F(#arg1),(arg1),F(op_name),op,F(#arg2),(arg2))) return; } while (0)
+namespace arduino_unit {
+  template< class T > struct remove_reference      {typedef T type;};
+  template< class T > struct remove_reference<T&>  {typedef T type;};
+  template< class T > struct remove_reference<T&&> {typedef T type;};
+}
 
+#if __cplusplus < 201103L
+#define decltype typeof
+#endif
+
+// helper define for the operators below
+#define assertOp(arg1,op,op_name,arg2) do { if (!Test::assertion<arduino_unit::remove_reference<decltype(arg1)>::type,arduino_unit::remove_reference<decltype(arg2)>::type>(F(__FILE__),__LINE__,F(#arg1),(arg1),F(op_name),op,F(#arg2),(arg2))) return; } while (0) 
 /** macro generates optional output and calls fail() followed by a return if false. */
 #define assertEqual(arg1,arg2)       assertOp(arg1,compareEqual,"==",arg2)
 

--- a/src/ArduinoUnit.h
+++ b/src/ArduinoUnit.h
@@ -446,40 +446,41 @@ class Test
   static void include(const char *pattern);
 
   /** 
-exclude (skip) currently included tests that match some
-wildcard (*) pattern like,
-  
-      "my_broken_test", "*_skip", "*", "io_*", etc.  
-  
-This should be done inside your setup() function.
+  exclude (skip) currently included tests that match some
+  wildcard (*) pattern like,
+    
+        "my_broken_test", "*_skip", "*", "io_*", etc.  
+    
+  This should be done inside your setup() function.
+    */
+  static void exclude(const char *pattern);
+
+  /**
+    
+  Simple usage:
+
+      void setup() {
+        Serial.begin(9600);
+      }
+      
+      void loop() {
+        Test::run();
+      }
+      
+  Complex usage:
+      
+      void setup() {
+        Test::exclude("*"); // exclude everything
+        Test::include("io_*"); // but include io_* tests
+        Test::exclude("io_*_lcd"); // except io_*_lcd tests
+        Test::include("crypto_*_aes128"); // and use all crypto_*_aes128 tests
+      }
+
+  void loop() {
+    Test::run();
+  }
   */
-static void exclude(const char *pattern);
 
-/**
-  
-Simple usage:
-
-    void setup() {
-      Serial.begin(9600);
-    }
-    
-    void loop() {
-      Test::run();
-    }
-    
-Complex usage:
-    
-    void setup() {
-      Test::exclude("*"); // exclude everything
-      Test::include("io_*"); // but include io_* tests
-      Test::exclude("io_*_lcd"); // except io_*_lcd tests
-      Test::include("crypto_*_aes128"); // and use all crypto_*_aes128 tests
-    }
-
-void loop() {
-  Test::run();
-}
-  */
   static void run();
 
   // Construct a test with a given name and verbosity level


### PR DESCRIPTION
This function can be used to run custom code on failure (e.g. to print some variable values at the time of the failure, such as [here](https://github.com/3devo/AtTinyBootloader/blob/94df47846863f0a6d5bf164bcf2b8a9f79eff315/BootloaderTest/BootloaderTest.ino#L363-L372)), or it can be used to let helper functions (that use the assert macros) return a value (e.g. [here](https://github.com/3devo/AtTinyBootloader/blob/94df47846863f0a6d5bf164bcf2b8a9f79eff315/BootloaderTest/BootloaderTest.ino#L130-L136) and [here](https://github.com/3devo/AtTinyBootloader/blob/94df47846863f0a6d5bf164bcf2b8a9f79eff315/BootloaderTest/BootloaderTest.ino#L183)).

This PR contains the commits from #64 too, since it touches the same lines and is built on top of those commits.
