### PR TITLE
Use correct include syntax

### DIFF
--- a/src/ArduinoUnit.h
+++ b/src/ArduinoUnit.h
@@ -35,10 +35,10 @@
 #define strlen_P(a) strlen(a)
 #endif
 
-#include <ArduinoUnitUtility/Compare.h>
-#include <ArduinoUnitUtility/FakeStream.h>
-#include <ArduinoUnitUtility/FakeStreamBuffer.h>
-#include <ArduinoUnitUtility/FreeMemory.h>
+#include "ArduinoUnitUtility/Compare.h"
+#include "ArduinoUnitUtility/FakeStream.h"
+#include "ArduinoUnitUtility/FakeStreamBuffer.h"
+#include "ArduinoUnitUtility/FreeMemory.h"
 
 /** \brief This is defined to manage the API transition to 2.X */
 #define ARDUINO_UNIT_MAJOR_VERSION 2

--- a/src/ArduinoUnitUtility/ArduinoUnit.cpp
+++ b/src/ArduinoUnitUtility/ArduinoUnit.cpp
@@ -1,5 +1,5 @@
 #include <Arduino.h>
-#include <ArduinoUnit.h>
+#include "../ArduinoUnit.h"
 
 const uint8_t Test::UNSETUP = 0;
 const uint8_t Test::LOOPING = 1;

--- a/src/ArduinoUnitUtility/FakeStream.h
+++ b/src/ArduinoUnitUtility/FakeStream.h
@@ -21,7 +21,7 @@ THE SOFTWARE.
 */
 #pragma once
 
-#include "Arduino.h"
+#include <Arduino.h>
 
 /**
  * A fake stream which can be used in place of other streams

--- a/src/ArduinoUnitUtility/FakeStreamBuffer.h
+++ b/src/ArduinoUnitUtility/FakeStreamBuffer.h
@@ -22,7 +22,7 @@ SOFTWARE.
 
 #pragma once
 
-#include "Arduino.h"
+#include <Arduino.h>
 #include "FakeStream.h"
 
 struct BufferNode {

--- a/src/ArduinoUnitUtility/FreeMemory.cpp
+++ b/src/ArduinoUnitUtility/FreeMemory.cpp
@@ -19,7 +19,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
-#include "Arduino.h"
+#include <Arduino.h>
 
 extern unsigned int __heap_start;
 extern void *__brkval;


### PR DESCRIPTION
Angle brackets for external includes. Quotes for local includes. The former is not critical but the latter is necessary in order to use the library when it's not in one of the standard Arduino libraries folders (such as when bundled with a sketch), where local files included with the angle brackets syntax will not be found in the include search path, causing compilation to fail:
```
fatal error: ArduinoUnitUtility/Compare.h: No such file or directory
```