### PR TITLE
Use relative paths in #includes of internal dependencies

### DIFF
--- a/src/ArduinoUnitUtility/ArduinoUnit.cpp
+++ b/src/ArduinoUnitUtility/ArduinoUnit.cpp
@@ -1,5 +1,5 @@
 #include <Arduino.h>
-#include <ArduinoUnit.h>
+#include "../ArduinoUnit.h"
 
 const uint8_t Test::UNSETUP = 0;
 const uint8_t Test::LOOPING = 1;

--- a/src/ArduinoUnitUtility/ArduinoUnitString.cpp
+++ b/src/ArduinoUnitUtility/ArduinoUnitString.cpp
@@ -1,5 +1,5 @@
 #include <Arduino.h>
-#include "ArduinoUnitUtility/ArduinoUnitString.h"
+#include "ArduinoUnitString.h"
 
 #if ARDUINO_UNIT_USE_FLASH  > 0
 ArduinoUnitString::ArduinoUnitString(const __FlashStringHelper *_data) : data(0x80000000|(uint32_t)_data) {}

--- a/src/ArduinoUnitUtility/ArduinoUnitString.h
+++ b/src/ArduinoUnitUtility/ArduinoUnitString.h
@@ -3,7 +3,7 @@
 #include <stdint.h>
 #include <WString.h>
 #include <Print.h>
-#include "ArduinoUnitUtility/Flash.h"
+#include "Flash.h"
 
 class ArduinoUnitString : public Printable {
  public:

--- a/src/ArduinoUnitUtility/Compare.h
+++ b/src/ArduinoUnitUtility/Compare.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <stdint.h>
-#include "ArduinoUnitUtility/Flash.h"
-#include "ArduinoUnitUtility/ArduinoUnitWiden.h"
+#include "Flash.h"
+#include "ArduinoUnitWiden.h"
 #include <WString.h>
 
 template  < typename A, typename B > struct Compare


### PR DESCRIPTION
Since https://github.com/mmurdoch/arduinounit/pull/69 was closed, here is another PR with the same goal, but applied to the updated code.

This change allows the library to be used when installed outside of the normal Arduino libraries folders. This allows the library to be bundled with a sketch so that it can be distributed as a self-contained package. Prior to this change, when the library was not installed to a standard Arduino libraries folder compilation of any sketch which included the library would fail:

C:\Users\per\AppData\Local\Temp\arduino_build_811257\sketch\src/ArduinoUnit/src/ArduinoUnitUtility/ArduinoUnitString.h:6:38: fatal error: ArduinoUnitUtility/Flash.h: No such file or directory

 #include "ArduinoUnitUtility/Flash.h"