### PR TITLE
added include <string.h> to fix the compilation errors of examples on Windows

### DIFF
--- a/src/ArduinoUnitUtility/ArduinoUnitString.h
+++ b/src/ArduinoUnitUtility/ArduinoUnitString.h
@@ -6,6 +6,7 @@
 #include <WString.h>
 #include <Print.h>
 #else
+#include <string.h> // memcpy, memset, strlen, strcmp
 #include <iostream>
 #include <string>
 #endif


### PR DESCRIPTION
Hi,

I am trying to get a unit testing framework running on Windows 10 and compile the In Vitro based on the arduinounit\examples\advanced\ using the makefile. I got a lot of error from the missing string.h includes (see bellow), so I suggest to add this missing include into the ArduinoUnitString.h header file.

See the source code use in https://github.com/martinjansa/rc433hq/tree/master/tests/rc433hq_tests.

Thanks,

Martin

Compilaton errors:

c:\Martin\Repositories\SmartHome\rc433hq\tests\rc433hq_tests>make
g++ -isystem C:\Users\martin/Documents/Arduino/libraries/ArduinoUnit/src -std=gnu++11 -o rc433hq_tests main.cpp C:\Users\martin/Documents/Arduino/libraries/ArduinoUnit/src/ArduinoUnitUtility/ArduinoUnitString.cpp C:\Users\martin/Documents/Arduino/libraries/ArduinoUnit/src/ArduinoUnitUtility/ArduinoUnit.cpp
C:\Users\martin/Documents/Arduino/libraries/ArduinoUnit/src/ArduinoUnitUtility/ArduinoUnitString.cpp: In member function 'void ArduinoUnitString::readTo(void*, uint16_t, uint8_t) const':
C:\Users\martin/Documents/Arduino/libraries/ArduinoUnit/src/ArduinoUnitUtility/ArduinoUnitString.cpp:39:40: error: 'memcpy' was not declared in this scope
   memcpy(destination,data+offset,length);
                                        ^
C:\Users\martin/Documents/Arduino/libraries/ArduinoUnit/src/ArduinoUnitUtility/ArduinoUnitString.cpp: In member function 'uint16_t ArduinoUnitString::length() const':
C:\Users\martin/Documents/Arduino/libraries/ArduinoUnit/src/ArduinoUnitUtility/ArduinoUnitString.cpp:51:21: error: 'strlen' was not declared in this scope
   return strlen(data);
                     ^
C:\Users\martin/Documents/Arduino/libraries/ArduinoUnit/src/ArduinoUnitUtility/ArduinoUnitString.cpp: In member function 'int8_t ArduinoUnitString::compareTo(const ArduinoUnitString&) const':
C:\Users\martin/Documents/Arduino/libraries/ArduinoUnit/src/ArduinoUnitUtility/ArduinoUnitString.cpp:97:32: error: 'strcmp' was not declared in this scope
   int ans = strcmp(data,to.data);
                                ^
C:\Users\martin/Documents/Arduino/libraries/ArduinoUnit/src/ArduinoUnitUtility/ArduinoUnitString.cpp: In member function 'bool ArduinoUnitString::matches(const char*) const':
C:\Users\martin/Documents/Arduino/libraries/ArduinoUnit/src/ArduinoUnitUtility/ArduinoUnitString.cpp:139:30: error: 'strlen' was not declared in this scope
   uint8_t np = strlen(pattern);
                              ^
C:\Users\martin/Documents/Arduino/libraries/ArduinoUnit/src/ArduinoUnitUtility/ArduinoUnitString.cpp:151:21: error: 'memset' was not declared in this scope
   memset(state0,0,nb);
                     ^
make: *** [Makefile:5: rc433hq_tests] Error 1
