### PR TITLE
 Put mergeable progmem strings in a separate section

### DIFF
--- a/src/ArduinoUnitUtility/Flash.h
+++ b/src/ArduinoUnitUtility/Flash.h
@@ -13,7 +13,7 @@
          PGM_P ptr;  \
          asm volatile \
          ( \
-           ".pushsection .progmem.data, \"SM\", @progbits, 1" "\n\t" \
+           ".pushsection .progmem.mergeable-strings, \"SM\", @progbits, 1" "\n\t" \
            "0: .string " #str                                 "\n\t" \
            ".popsection"                                      "\n\t" \
          ); \

--- a/src/ArduinoUnitUtility/Flash.h
+++ b/src/ArduinoUnitUtility/Flash.h
@@ -14,13 +14,13 @@
          asm volatile \
          ( \
            ".pushsection .progmem.mergeable-strings, \"SM\", @progbits, 1" "\n\t" \
-           "0: .string " #str                                 "\n\t" \
-           ".popsection"                                      "\n\t" \
+           "0: .string " #str                                              "\n\t" \
+           ".popsection"                                                   "\n\t" \
          ); \
          asm volatile \
          ( \
-           "ldi %A0, lo8(0b)"                                 "\n\t" \
-           "ldi %B0, hi8(0b)"                                 "\n\t" \
+           "ldi %A0, lo8(0b)"                                              "\n\t" \
+           "ldi %B0, hi8(0b)"                                              "\n\t" \
            : "=d" (ptr) \
          ); \
          ptr; \


### PR DESCRIPTION
The `ARDUINO_UNIT_PSTR` macro puts strings in the .progmem.data section,
and set the S (contains zero terminated strings) and M (mergeable)
attributes. Unlike the normal PROGMEM/PSTR macros, which do not set
these attributes, this allows for merging of duplicate or partly
overlapping strings.

However, when the regular PROGMEM attribute is also used, this will put
other variables into the same .progmem.data section, but without these
attributes. The compiler complains about this:

	/tmp/cco2ytva.s: Assembler messages:
	/tmp/cco2ytva.s:2658: Warning: ignoring changed section attributes for .progmem.data

This seems harmless, but effectively causes the SM attributes to be
applied to all progmem data, making the linker believe that all progmem
data consists of mergeable zero-terminated strings, which can cause
problems. For example, when progmem contains any variables with embedded
zeroes, these variables will be truncated at the first embedded zero
(but the code accessing these variables is unchanged, so these will
access data from the next variable instead).

For example, the `port_to_output_PGM` variable for the Arduino mega
(variants/mega/pins_arduino.h) is one such variable, which contains
embedded zeroes and is put into progmem. The following sketch can
reproduce this problem:

	#include <ArduinoUnit.h>

	void setup() {
	  assertTrue(true);
	  digitalWrite(0, LOW);
	}

	void loop() { }

After compiling this sketch for the Arduino Mega2560, the generated
symbol table looks like this:

	$ avr-objdump -t sketch.elf --demangle|sort|grep port_to_output_PGM -A 1
	00000156 l     O .text  0000001a port_to_output_PGM
	0000015d l     O .text  00000056 digital_pin_to_port_PGM

As you can see, the port_to_output_PGM is 0x1a bytes long and should
take space up to 0x156+0x1a = 0x170, but the next variable starts at
0x15d already.

It seems that for other boards, such as the Arduino Uno, these variables
do not contain any embedded zeroes (only leading zeroes, which
apparently are not a problem), so the problem does not surface there.

To fix this, this commit changes the section name used by the
`ARDUINO_UNIT_PSTR` macro to `.progmem.mergeable-strings`, so the
section attribute only affects these particular strings, and not other
progmem data.

The linker scripts used by avr-libc use a wildcard `*(.progmem*)` to
include progmem symbols, so any sections starting with `.progmem` are
included in the link (checked in avr-libc 1:1.8.0+Atmel3.5.0-1 from
Debian that all linker scripts that reference progmem use the wildcard).