### PR TITLE
Allow running tests multiple times

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,55 @@ void setup()
 }
 ```
 
+## Re-running tests (advanced)
+Typically, you just want to run all tests once and then show the result.
+If so, you can skip this section.
+
+In more advanced situations, you might want to run the entire test suite
+multiple times (for example if your tests can be configured with
+different parameters). To facilitate this, you can use the
+`Test::resetDoneTests()` function.
+
+Calling this function will reset all completed tests (passed, failed or
+skipped) back to their initial state. For tests that define a `setup`
+method, this will be run again on the next `Test::run()`. If any tests
+were not completed yet, these are unaffected. The statistics (number of
+passed, failed and skipped tests) are also reset to 0.
+
+Note that excluded tests (using `Test::exclude()`) are treated as
+skipped tests, so these are also re-run (you will need to call
+`Test::exclude()` again after `resetDoneTests()` if you want keep these
+tests excluded). Tests removed with their `remove()` method are really
+removed, so not re-run when using `resetDoneTests()`.
+
+Typically, you would use this after all tests are completed (but if you
+call `resetDoneTests()` when some tests are still pending, those
+tests are unaffected). You must never call `resetDoneTests()` from
+inside a test, only between calls to `Test::run()`.
+
+Below is an example that runs all tests once, then changes a global
+variable and runs all tests again. To have a bit more direct control
+over running the tests, this example does not call `Test::run()`
+infinitely in the `loop()`, but instead uses `Test:runUntilDone()` which
+repeatedly calls `Test::run()` until all tests are completed.
+
+```
+bool some_global_setting = false;
+
+void setup() {
+  Serial.begin(9600);
+  while(!Serial) {} // Portability for Leonardo/Micro
+
+  Test::runUntilDone();
+
+  some_global_setting = true;
+  Test::resetDoneTests();
+  Test::runUntilDone();
+}
+
+void loop() { }
+```
+
 # Output
 
 The `Test::out` value is the *shared* value for all tests describing where output for all tests goes.  The default is 

--- a/src/ArduinoUnit.h
+++ b/src/ArduinoUnit.h
@@ -293,6 +293,9 @@ class Test
  private:
   // linked list structure for active tests
   static Test* root;
+  // linked list structure for done tests. This includes skipped tests,
+  // though they are only moved after Test::run() finds them.
+  static Test* done;
   Test *next;
 
   // static statistics for tests

--- a/src/ArduinoUnit.h
+++ b/src/ArduinoUnit.h
@@ -430,6 +430,16 @@ class Test
   /** Run a test.  Test::loop() will be called on each Test::run() until a pass(), fail() or skip(). */
   virtual void loop() = 0;
 
+  /**
+   * Reset all done tests (including skipped tests), so they can be run
+   * again, and reset the counters to reflect this. Any tests that are
+   * not completed are unaffected.
+   *
+   * Should never be called from inside a test, but only between calls
+   * to Test::run() (and typically only when all tests are done).
+   */
+  static void resetDoneTests();
+
   /** include (use) currently excluded (skipped) tests that match some
   wildcard (*) pattern like,
   

--- a/src/ArduinoUnit.h
+++ b/src/ArduinoUnit.h
@@ -489,6 +489,9 @@ void loop() {
   */
   static void run();
 
+  /** Repeatedly call run until all tests are done */
+  static void runUntilDone();
+
   /** number of tests that have are not done (skipped, passed, or failed) */
   static int remaining();
 

--- a/src/ArduinoUnitUtility/ArduinoUnit.cpp
+++ b/src/ArduinoUnitUtility/ArduinoUnit.cpp
@@ -14,6 +14,7 @@ const uint8_t Test::DONE_FAIL = 4;
 
 
 Test* Test::root = 0;
+Test* Test::done = 0;
 Test* Test::current = 0;
 
 uint16_t Test::count = 0;
@@ -146,7 +147,13 @@ void Test::run()
     }
 
     if (current->state != LOOPING) {
+      // Remove from root list
       (*p)=((*p)->next);
+
+      // Add to done list
+      current->next = done;
+      done = current;
+
       current->resolve();
     } else {
       p=&((*p)->next);
@@ -170,6 +177,8 @@ void Test::abort()
     Test::out->print(__LINE__);
     Test::out->println(ARDUINO_UNIT_STRING("."));
     root=root->next;
+    current->next = done;
+    done = current;
     current->resolve();
   }
   current=0;

--- a/src/ArduinoUnitUtility/ArduinoUnit.cpp
+++ b/src/ArduinoUnitUtility/ArduinoUnit.cpp
@@ -99,12 +99,14 @@ Test::Test(const __FlashStringHelper *_name, uint8_t _verbosity)
   : name(_name), verbosity(_verbosity)
 {
   insert();
+  ++Test::count;
 }
 
 Test::Test(const char *_name, uint8_t _verbosity)
   : name(_name), verbosity(_verbosity)
 {
   insert();
+  ++Test::count;
 }
 
 void Test::insert()
@@ -119,7 +121,6 @@ void Test::insert()
     next=(*p);
     (*p)=this;
   }
-  ++Test::count;
 }
 
 void Test::pass() { if (current != 0) current->state = DONE_PASS; }

--- a/src/ArduinoUnitUtility/ArduinoUnit.cpp
+++ b/src/ArduinoUnitUtility/ArduinoUnit.cpp
@@ -167,6 +167,11 @@ void Test::run()
   current = 0;
 }
 
+void Test::runUntilDone() {
+  while (Test::root != 0)
+    Test::run();
+}
+
 void Test::abort()
 {
   while (root != 0) {

--- a/src/ArduinoUnitUtility/ArduinoUnit.cpp
+++ b/src/ArduinoUnitUtility/ArduinoUnit.cpp
@@ -190,6 +190,17 @@ Test::~Test()
   remove();
 }
 
+void Test::resetDoneTests() {
+  Test::passed = Test::failed = Test::skipped = 0;
+  Test *p = done;
+  while (p != 0) {
+    Test *next = p->next;
+    p->insert();
+    p = next;
+  }
+  done = 0;
+}
+
 void Test::include(const char *pattern)
 {
   for (Test *p = root; p != 0; p=p->next) {


### PR DESCRIPTION
This PR adds support to run tests (typically the whole test suite) multiple times, by resetting tests that are marked as done. It also adds a convenience helper function `Test::runUntilDone()` which repeatedly runs any pending tests until all of them are done.

This fixes #61.