### PR TITLE
Fix incorrect merging of PROGMEM strings

### DIFF
--- a/src/ArduinoUnitUtility/ArduinoUnit.cpp
+++ b/src/ArduinoUnitUtility/ArduinoUnit.cpp
@@ -29,19 +29,6 @@ static CppStreamPrint Serial;
 
 Print* Test::out = &Serial;
 
-#if ARDUINO_UNIT_USE_FLASH > 0
-#define ARDUINO_UNIT_PROGMEM PROGMEM
-#else
-#define ARDUINO_UNIT_PROGMEM
-#endif
-
-const char CONST_SKIPPED[] ARDUINO_UNIT_PROGMEM = "skipped";
-const char CONST_PASSED[]  ARDUINO_UNIT_PROGMEM = "passed";
-const char CONST_FAILED[]  ARDUINO_UNIT_PROGMEM = "failed";
-
-ARDUINO_UNIT_DECLARE_STRING SKIPPED = (ARDUINO_UNIT_DECLARE_STRING) CONST_SKIPPED;
-ARDUINO_UNIT_DECLARE_STRING PASSED = (ARDUINO_UNIT_DECLARE_STRING) CONST_PASSED;
-ARDUINO_UNIT_DECLARE_STRING FAILED = (ARDUINO_UNIT_DECLARE_STRING) CONST_FAILED;
 
 void Test::noMessage(bool ok) { (void) ok; }
 
@@ -51,12 +38,11 @@ void Test::resolve()
   bool fail = state==DONE_FAIL;
   bool skip = state==DONE_SKIP;
   bool done = (pass || fail || skip);
-  ARDUINO_UNIT_DECLARE_STRING  message = 0;
   
   if (done) {
-    if (pass) { message=PASSED; ++Test::passed; }
-    if (fail) { message=FAILED; ++Test::failed; }
-    if (skip) { message=SKIPPED; ++Test::skipped; }
+    if (pass) ++Test::passed;
+    if (fail) ++Test::failed;
+    if (skip) ++Test::skipped;
     
 #if TEST_VERBOSITY_EXISTS(TESTS_SKIPPED) || TEST_VERBOSITY_EXISTS(TESTS_PASSED) || TEST_VERBOSITY_EXISTS(TESTS_FAILED)
     
@@ -69,9 +55,17 @@ void Test::resolve()
     if (output) {
       Test::out->print(ARDUINO_UNIT_STRING("Test "));
       Test::out->print(name);
-      Test::out->print(' ');  
-      Test::out->print(message);
-      Test::out->println();
+#if TEST_VERBOSITY_EXISTS(TESTS_SKIPPED)
+      if (skip) { Test::out->println(ARDUINO_UNIT_STRING(" skipped.")); }
+#endif
+
+#if TEST_VERBOSITY_EXISTS(TESTS_PASSED)
+      if (pass) { Test::out->println(ARDUINO_UNIT_STRING(" passed.")); }
+#endif
+
+#if TEST_VERBOSITY_EXISTS(TESTS_FAILED)
+      if (fail) { Test::out->println(ARDUINO_UNIT_STRING(" failed.")); }
+#endif
     }
 #endif
   }
@@ -79,17 +73,11 @@ void Test::resolve()
   if (root == 0 && TEST_VERBOSITY(TESTS_SUMMARY)) {
     Test::out->print(ARDUINO_UNIT_STRING("Test summary: "));
     Test::out->print(passed);
-    Test::out->print(' ');
-    Test::out->print(PASSED);
-    Test::out->print(ARDUINO_UNIT_STRING(", "));
+    Test::out->print(ARDUINO_UNIT_STRING(" passed, "));
     Test::out->print(failed);
-    Test::out->print(' ');
-    Test::out->print(FAILED);
-    Test::out->print(ARDUINO_UNIT_STRING(", "));    
+    Test::out->print(ARDUINO_UNIT_STRING(" failed, and "));
     Test::out->print(skipped);
-    Test::out->print(' ');
-    Test::out->print(SKIPPED);
-    Test::out->print(ARDUINO_UNIT_STRING(", out of "));
+    Test::out->print(ARDUINO_UNIT_STRING(" skipped, out of "));
     Test::out->print(count);
     Test::out->println(ARDUINO_UNIT_STRING(" test(s)."));
   }

--- a/src/ArduinoUnitUtility/Flash.h
+++ b/src/ArduinoUnitUtility/Flash.h
@@ -8,23 +8,32 @@
 //
 //   http://michael-buschbeck.github.io/arduino/2013/10/22/string-merging-pstr-percent-codes/
 //
-#    define ARDUINO_UNIT_PSTR(str) \
+// This additionally uses __COUNTER__ for generating unique labels,
+// since backreferencing a fixed label 0 as suggested in the above url
+// breaks (probably in recent compiler version, probably because it
+// reorders asm blocks).
+
+#    define ARDUINO_UNIT_PSTR2(str, counter) \
        (__extension__({ \
-         PGM_P ptr ## __COUNTER__;  \
+         PGM_P ptr;  \
          asm volatile \
          ( \
            ".pushsection .progmem.mergeable-strings, \"SM\", @progbits, 1" "\n\t" \
-           "0: .string " #str                                              "\n\t" \
+           #counter ": .string " #str                                      "\n\t" \
            ".popsection"                                                   "\n\t" \
          ); \
          asm volatile \
          ( \
-           "ldi %A0, lo8(0b)"                                              "\n\t" \
-           "ldi %B0, hi8(0b)"                                              "\n\t" \
-           : "=d" (ptr ## __COUNTER__) \
+           "ldi %A0, lo8(" #counter "b)"                                   "\n\t" \
+           "ldi %B0, hi8(" #counter "b)"                                   "\n\t" \
+           : "=d" (ptr) \
          ); \
-         ptr ## __COUNTER__ ; \
+         ptr; \
        }))
+// Use a three-layer macro to ensure that __COUNTER__ is expanded before
+// stringification above.
+#    define ARDUINO_UNIT_PSTR1(str, counter) ARDUINO_UNIT_PSTR2(str, counter)
+#    define ARDUINO_UNIT_PSTR(str) ARDUINO_UNIT_PSTR1(str, __COUNTER__)
 #    define ARDUINO_UNIT_STRING(STR) (reinterpret_cast<const __FlashStringHelper *>(ARDUINO_UNIT_PSTR(STR)))
 #    define ARDUINO_UNIT_DECLARE_STRING const __FlashStringHelper *
 #    define ARDUINO_UNIT_USE_FLASH 1


### PR DESCRIPTION
This fixes the ARDUINO_UNIT_PSTR macro to not reference the wrong
string. In particular, this makes failing macros not output "passed"
instead of "failed".

The same problem was seemingly the subject of commit 60840b8 (not all
skipped.). That commit fixed the problem for test status by not using
the ARDUINO_UNIT_PSTR macro, and seems to contain a half fix for
ARDUINO_UNIT_PSTR using __COUNTER__, but the way it was used,
__COUNTER__ was never actually expanded, so that did not help (also, it
tried to apply __COUNTER__ in the wrong place).

The actual problem *seems* to be that the `0:` label used to reference
the string constant is not actually unique. It should not need to be,
since the `0b` reference should just reference the nearest label 0,
going backwards, but I suspect that gcc ends up reordering asm blocks
and thus messes up the reference. Using a unique (but still numerical so
local) label seems to fix this. See e.g. this thread about reordering of
asm blocks:

https://gcc.gnu.org/legacy-ml/gcc-help/2017-10/msg00061.html

So, this commit reverts the __COUNTER__ bit from that commit, just using
the plain `ptr` name again (which does not need to be unique, since it
is local the the __extension__ block). It also reverts the changes
around the test status, so these now use ARDUINO_UNIT_STRING again as
originally.

Then, it applies a two-layer macro wrapper for ARDUINO_UNIT_PSTR, that
ensures that __COUNTER__ is actually expanded before being used (which
is needed when using a macro as part of a stringification or
concatenation) and ensures that __COUNTER__ is only expanded once, with
one value, rather than with different values in all three places.

Finally, this commit uses this expanded counter value to generate
unique labels, which seems to prevent this problem from occuring.